### PR TITLE
Improve hardware BOM links and summary

### DIFF
--- a/Hardware list.md
+++ b/Hardware list.md
@@ -1,74 +1,326 @@
-Preliminary list of hardware needed:
+# Cyberdeck Hardware Bill of Materials
 
-Cyberdeck Bill of material
-1 x rasberry pi 5 8gb
+This list keeps the original creator reference links unchanged while adding generic search links for users who need local suppliers or a quick price comparison.
 
-https://no.rs-online.com/web/p/raspberry-pi/0219255?cm_mmc=NO-PLA-DS3A-_-google-_-CSS_NO_EN_Pmax_Test-_--_-219255&matchtype=&&gclsrc=aw.ds&gad_source=1&gad_campaignid=20298225819&gbraid=0AAAAADkeWNNM22_IVzPWWPXKteiN9dU3n&gclid=CjwKCAiAkvDMBhBMEiwAnUA9Bda0b4-84Nr2l1eq-tLgsCP1wFOeHvoippWgN7HSQk9cVJ-S7HWWQBoCJtIQAvD_BwE
+Creator links may still point to the supplier or country used by the original build, and may include affiliate or tracking parameters. Generic search links use DuckDuckGo as a browser-based fallback because there is no universal URL standard for opening the user's preferred search engine.
 
-1 x joy-it power supply module
+## Summary
 
-https://www.kjell.com/no/produkter/data/raspberry-pi/joy-it-stromstyringskort-for-raspberry-pi-3-4-og-5-p88409?utm_source=google&utm_medium=cpc&utm_campaign=NO%20%7C%20Shopping%20Category&utm_id=23554678753&gad_source=1&gad_campaignid=23554678753&gbraid=0AAAAADcA9cwm7tEi4DGEqshMJOQGAZmGM&gclid=CjwKCAiAkvDMBhBMEiwAnUA9Bb11cW340NAFo1qricJX56ATAIpR24Xnc7_1AqccmRroMTKr5KwlcxoCHooQAvD_BwE
+| Component | Quantity | Creator link | Generic link |
+| --- | --- | --- | --- |
+| [Raspberry Pi 5, 8 GB](#raspberry-pi-5-8-gb) | 1 | [link](https://no.rs-online.com/web/p/raspberry-pi/0219255?cm_mmc=NO-PLA-DS3A-_-google-_-CSS_NO_EN_Pmax_Test-_--_-219255&matchtype=&&gclsrc=aw.ds&gad_source=1&gad_campaignid=20298225819&gbraid=0AAAAADkeWNNM22_IVzPWWPXKteiN9dU3n&gclid=CjwKCAiAkvDMBhBMEiwAnUA9Bda0b4-84Nr2l1eq-tLgsCP1wFOeHvoippWgN7HSQk9cVJ-S7HWWQBoCJtIQAvD_BwE) | [link](https://duckduckgo.com/?q=Raspberry+Pi+5+8GB) |
+| [Joy-IT Power Management Board](#joy-it-power-management-board-for-raspberry-pi) | 1 | [link](https://www.kjell.com/no/produkter/data/raspberry-pi/joy-it-stromstyringskort-for-raspberry-pi-3-4-og-5-p88409?utm_source=google&utm_medium=cpc&utm_campaign=NO%20%7C%20Shopping%20Category&utm_id=23554678753&gad_source=1&gad_campaignid=23554678753&gbraid=0AAAAADcA9cwm7tEi4DGEqshMJOQGAZmGM&gclid=CjwKCAiAkvDMBhBMEiwAnUA9Bb11cW340NAFo1qricJX56ATAIpR24Xnc7_1AqccmRroMTKr5KwlcxoCHooQAvD_BwE) | [link](https://duckduckgo.com/?q=joy+it+energy+mini) |
+| [Raspberry Pi 5 Aluminum Cooling Case](#raspberry-pi-5-aluminum-cooling-case) | 1 | [link](https://www.kjell.com/no/produkter/data/raspberry-pi/joy-it-robust-aluminiumskabinett-for-raspberry-pi-5-p88410) | [link](https://duckduckgo.com/?q=Joy-IT+robust+aluminum+case+Raspberry+Pi+5) |
+| [NP-F970 Battery With USB-C Input](#np-f970-battery-with-usb-c-input) | 1 | [link](https://www.scandinavianphoto.no/jupio/np-f970-10050mah-usb-c-input-1061086?_gl=1*1egj611*_up*MQ..*_gs*MQ..&gclid=CjwKCAiAkvDMBhBMEiwAnUA9BY5sMGsIEGkahJAyACMaOqKd51eR54hWRQpXCfJpuzd1-8D9EK2UQRoCTAUQAvD_BwE&gbraid=0AAAAAD7wLDBaqEHkDx796WWIzLpQ90hlU) | [link](https://duckduckgo.com/?q=NP-F970+10050mAh+USB-C+input+battery) |
+| [10.1 Inch IPS Touch LCD](#101-inch-ips-touch-lcd) | 1 | [link](https://www.aliexpress.com/item/1005001311947746.html?spm=a2g0o.productlist.main.5.d607qHnDqHnDg5&algo_pvid=f733027e-e3b3-40c4-82aa-fa6762af9178&algo_exp_id=f733027e-e3b3-40c4-82aa-fa6762af9178-4&pdp_ext_f=%7B%22order%22%3A%22203%22%2C%22eval%22%3A%221%22%2C%22fromPage%22%3A%22search%22%7D&pdp_npi=6%40dis%21EUR%2162.27%2158.94%21%21%21494.96%21468.50%21%40211b80d117718496044041525e8452%2112000015661776796%21sea%21NO%21905713470%21X%211%210%21n_tag%3A-29919%3Bd%3Ac3ce268b%3Bm03_new_user%3A-29895&curPageLogUid=q2qqPFQmRrBm&utparam-url=scene%3Asearch%7Cquery_from%3A%7Cx_object_id%3A1005001311947746%7C_p_origin_prod%3A) | [link](https://duckduckgo.com/?q=10.1+inch+IPS+touch+LCD+HDMI+Raspberry+Pi) |
+| [Micro-HDMI Ribbon Cable Set](#micro-hdmi-ribbon-cable-set) | 1 set | [link](https://www.aliexpress.com/item/1005001591237744.html?spm=a2g0o.productlist.main.4.316cU0ggU0ggIg&aem_p4p_detail=2026022304173411405903031933080003173417&algo_pvid=69baf832-79ef-4f1e-8588-e22392534c15&algo_exp_id=69baf832-79ef-4f1e-8588-e22392534c15-3&pdp_ext_f=%7B%22order%22%3A%221975%22%2C%22eval%22%3A%221%22%2C%22fromPage%22%3A%22search%22%7D&pdp_npi=6%40dis%21EUR%210.61%210.61%21%21%210.70%210.70%21%4021038e6617718490545856138e3334%2112000016707628678%21sea%21NO%21905713470%21X%211%210%21n_tag%3A-29919%3Bd%3Ac3ce268b%3Bm03_new_user%3A-29895&curPageLogUid=EAp8SScI4vH4&utparam-url=scene%3Asearch%7Cquery_from%3A%7Cx_object_id%3A1005001591237744%7C_p_origin_prod%3A&search_p4p_id=2026022304173411405903031933080003173417_1) | [link](https://duckduckgo.com/?q=micro+HDMI+90+degree+ribbon+cable+50cm+HDMI+male) |
+| [NOS C-450 Mini Pro RGB Keyboard](#nos-c-450-mini-pro-rgb-keyboard) | 1 | [link](https://www.elkjop.no/product/pc-datautstyr-og-kontor/pc-tilbehor/mus-tastatur/tastatur/nos-c-450-mini-pro-rgb-gamingtastatur-1973/327262) | [link](https://duckduckgo.com/?q=NOS+C-450+Mini+PRO+RGB+gamingtastatur+%281973%29) |
+| [Logitech Trackman Marble trackball](#trackball-donor-electronics) | 1 | N/A | [link](https://duckduckgo.com/?q=logitech+trackman+marble) |
+| [2-pin self-locking connector variant for power module](#0b-self-locking-connector-sets) | 1 set minimum | [link](https://www.aliexpress.com/item/1005008630749310.html?spm=a2g0o.order_list.order_list_main.226.2ac11802y60YIY) | [link](https://duckduckgo.com/?q=0B+self+locking+push+pull+connector+male+female) |
+| [4-pin self-locking connector variant for trackball or USB module](#0b-self-locking-connector-sets) | 1 set minimum | [link](https://www.aliexpress.com/item/1005008630749310.html?spm=a2g0o.order_list.order_list_main.226.2ac11802y60YIY) | [link](https://duckduckgo.com/?q=0B+self+locking+push+pull+connector+male+female) |
+| [2B Self-Locking Connector With Female Plug](#2b-self-locking-connector-with-female-plug) | 1 | [link](https://www.aliexpress.com/item/1005005348326872.html?spm=a2g0o.productlist.main.12.27bdL3YdL3YdfY&aem_p4p_detail=20260223041952939481064044600002923257&algo_pvid=9d335b38-f0bc-4a89-b765-3f67b99217db&algo_exp_id=9d335b38-f0bc-4a89-b765-3f67b99217db-11&pdp_ext_f=%7B%22order%22%3A%22555%22%2C%22eval%22%3A%221%22%2C%22fromPage%22%3A%22search%22%7D&pdp_npi=6%40dis%21EUR%2111.16%218.03%21%21%2112.88%219.27%21%40210384b217718491920953005e4d67%2112000032708276815%21sea%21NO%21905713470%21X%211%210%21n_tag%3A-29919%3Bd%3Ac3ce268b%3Bm03_new_user%3A-29895&curPageLogUid=74deDfk1d9z9&utparam-url=scene%3Asearch%7Cquery_from%3A%7Cx_object_id%3A1005005348326872%7C_p_origin_prod%3A&search_p4p_id=20260223041952939481064044600002923257_3) | [link](https://duckduckgo.com/?q=2B+self+locking+push+pull+connector+female+plug) |
+| [Y2M 8-Pin Connector Sets](#y2m-8-pin-connector-sets) | 2 sets | [link](https://www.aliexpress.com/item/4000650649567.html?spm=a2g0o.productlist.main.1.6e644abalUtqB9&algo_pvid=f078181e-900f-4d18-8942-ab93a7526c4e&algo_exp_id=f078181e-900f-4d18-8942-ab93a7526c4e-0&pdp_ext_f=%7B%22order%22%3A%22227%22%2C%22eval%22%3A%221%22%2C%22fromPage%22%3A%22search%22%7D&pdp_npi=6%40dis%21EUR%212.99%212.99%21%21%213.45%213.45%21%4021038e6617718491097817431e3334%2110000005200204781%21sea%21NO%21905713470%21X%211%210%21n_tag%3A-29919%3Bd%3Ac3ce268b%3Bm03_new_user%3A-29895&curPageLogUid=ntdSUsUGDLOf&utparam-url=scene%3Asearch%7Cquery_from%3A%7Cx_object_id%3A4000650649567%7C_p_origin_prod%3A) | [link](https://duckduckgo.com/?q=Y2M+8+pin+connector+male+female) |
+| [Pogo Pin GF50-09140-4024](#pogo-pin-gf50-09140-4024) | 2 | [link](https://www.aliexpress.com/item/1005004693750812.html?spm=a2g0o.productlist.main.4.fe8a7510uZDa8O&algo_pvid=e355b9b1-a66a-465b-bca3-e3311b2fd34a&aem_p4p_detail=2026022303573510910880972595240003164091&algo_exp_id=e355b9b1-a66a-465b-bca3-e3311b2fd34a-3&pdp_ext_f=%7B%22order%22%3A%22384%22%2C%22eval%22%3A%221%22%2C%22fromPage%22%3A%22search%22%7D&pdp_npi=6%40dis%21EUR%212.46%212.36%21%21%212.84%212.72%21%40211b815c17718478555706424eb2a1%2112000038034838423%21sea%21NO%21905713470%21X%211%210%21n_tag%3A-29919%3Bd%3Ac3ce268b%3Bm03_new_user%3A-29895%3BpisId%3A5000000200980252&curPageLogUid=xG00PYGQ8IYg&utparam-url=scene%3Asearch%7Cquery_from%3A%7Cx_object_id%3A1005004693750812%7C_p_origin_prod%3A&search_p4p_id=2026022303573510910880972595240003164091_1) | [link](https://duckduckgo.com/?q=GF50-09140-4024+pogo+pin) |
+| [Rotary Encoder With Push Button](#rotary-encoder-with-push-button) | 1 | [link](https://www.aliexpress.com/item/1005006128088045.html?spm=a2g0o.productlist.main.1.91a366925vXHcn&algo_pvid=1fe69f4c-fb30-4c2c-bf02-2721e63c6bed&algo_exp_id=1fe69f4c-fb30-4c2c-bf02-2721e63c6bed-0&pdp_ext_f=%7B%22order%22%3A%22541%22%2C%22eval%22%3A%221%22%2C%22fromPage%22%3A%22search%22%7D&pdp_npi=6%40dis%21EUR%212.36%212.27%21%21%212.72%212.62%21%40211b815c17718484316555889eb2a0%2112000035881381466%21sea%21NO%21905713470%21X%211%210%21n_tag%3A-29919%3Bd%3Ac3ce268b%3Bm03_new_user%3A-29895&curPageLogUid=AQqsQHsG0Sc4&utparam-url=scene%3Asearch%7Cquery_from%3A%7Cx_object_id%3A1005006128088045%7C_p_origin_prod%3A) | [link](https://duckduckgo.com/?q=rotary+encoder+with+push+button+shaft) |
+| [16 mm Momentary Push Buttons](#16-mm-momentary-push-buttons) | 3 | [link](https://www.aliexpress.com/item/1005009579949777.html?spm=a2g0o.productlist.main.1.3ace23f0HeYR1S&algo_pvid=5867ac58-f6e8-44ff-a2ff-2d26cb5e8f4e&algo_exp_id=5867ac58-f6e8-44ff-a2ff-2d26cb5e8f4e-0&pdp_ext_f=%7B%22order%22%3A%226%22%2C%22eval%22%3A%221%22%2C%22fromPage%22%3A%22search%22%7D&pdp_npi=6%40dis%21EUR%213.85%213.68%21%21%2130.64%2129.28%21%40211b612817718484586922153ef972%2112000049522702615%21sea%21NO%21905713470%21X%211%210%21n_tag%3A-29919%3Bd%3Ac3ce268b%3Bm03_new_user%3A-29895&curPageLogUid=ZhxhZ2yxGIzJ&utparam-url=scene%3Asearch%7Cquery_from%3A%7Cx_object_id%3A1005009579949777%7C_p_origin_prod%3A) | [link](https://duckduckgo.com/?q=16mm+Panel+Hole+Metal+Button+Switch) |
+| [12 x 12 mm Tactile Buttons](#12-x-12-mm-tactile-buttons) | 10 | [link](https://www.aliexpress.com/item/1005010485096642.html?spm=a2g0o.productlist.main.1.25fe2d51zABxOU&algo_pvid=221d32c1-86d5-4a50-b5f3-c482f58dcdfc&algo_exp_id=221d32c1-86d5-4a50-b5f3-c482f58dcdfc-0&pdp_ext_f=%7B%22order%22%3A%22158%22%2C%22spu_best_type%22%3A%22price%22%2C%22eval%22%3A%221%22%2C%22fromPage%22%3A%22search%22%7D&pdp_npi=6%40dis%21EUR%213.36%211.39%21%21%2126.74%2111.06%21%40211b6a7a17718496413512900e0633%2112000052561945672%21sea%21NO%21905713470%21X%211%210%21n_tag%3A-29919%3Bd%3Ac3ce268b%3Bm03_new_user%3A-29895%3BpisId%3A5000000200970435&curPageLogUid=1PbE81DGYibH&utparam-url=scene%3Asearch%7Cquery_from%3A%7Cx_object_id%3A1005010485096642%7C_p_origin_prod%3A) | [link](https://duckduckgo.com/?q=Tactile+Push+Button+Switch+Momentary+12*12*7.3MM) |
+| [12 mm Momentary Push Button](#12-mm-momentary-push-button) | 1 | [link](https://www.aliexpress.com/item/1005010335756032.html?spm=a2g0o.productlist.main.5.54c63653Lc8MFB&algo_pvid=6d81dff8-3297-4705-95c2-77e3f2fe94c9&algo_exp_id=6d81dff8-3297-4705-95c2-77e3f2fe94c9-4&pdp_ext_f=%7B%22order%22%3A%2257%22%2C%22eval%22%3A%221%22%2C%22fromPage%22%3A%22search%22%7D&pdp_npi=6%40dis%21EUR%219.83%214.25%21%21%2178.12%2133.78%21%40211b618e17718485069396564eebdd%2112000052021992055%21sea%21NO%21905713470%21X%211%210%21n_tag%3A-29919%3Bd%3Ac3ce268b%3Bm03_new_user%3A-29895%3BpisId%3A5000000200974340&curPageLogUid=QfkSBUw4SyuI&utparam-url=scene%3Asearch%7Cquery_from%3A%7Cx_object_id%3A1005010335756032%7C_p_origin_prod%3A) | [link](https://duckduckgo.com/?q=12mm+momentary+push+button+panel+mount) |
+| [6 mm ON-ON Toggle Switch](#6-mm-on-on-toggle-switch) | 1 | [link](https://www.aliexpress.com/item/1005005919234155.html?spm=a2g0o.productlist.main.29.6ac3S5V5S5V5Xm&algo_pvid=a7523d10-969b-494e-b433-d31603133085&algo_exp_id=a7523d10-969b-494e-b433-d31603133085-28&pdp_ext_f=%7B%22order%22%3A%22296%22%2C%22eval%22%3A%221%22%2C%22fromPage%22%3A%22search%22%7D&pdp_npi=6%40dis%21EUR%210.62%210.62%21%21%210.72%210.72%21%40211b619a17718489119092560eb5c6%2112000034852814775%21sea%21NO%21905713470%21X%211%210%21n_tag%3A-29919%3Bd%3Ac3ce268b%3Bm03_new_user%3A-29895&curPageLogUid=mUMB35geuwId&utparam-url=scene%3Asearch%7Cquery_from%3A%7Cx_object_id%3A1005005919234155%7C_p_origin_prod%3A) | [link](https://duckduckgo.com/?q=6mm+ON-ON+mini+toggle+switch) |
+| [6 mm ON-OFF-ON Momentary Toggle Switch](#6-mm-on-off-on-momentary-toggle-switch) | 1 | [link](https://www.aliexpress.com/item/1005005508763350.html?spm=a2g0o.productlist.main.10.7642DKEODKEORj&algo_pvid=b16efa23-27fe-414c-9dbe-dd0c58a3931f&algo_exp_id=b16efa23-27fe-414c-9dbe-dd0c58a3931f-9&pdp_ext_f=%7B%22order%22%3A%22226%22%2C%22spu_best_type%22%3A%22price%22%2C%22eval%22%3A%221%22%2C%22fromPage%22%3A%22search%22%7D&pdp_npi=6%40dis%21EUR%211.64%211.42%21%21%211.89%211.64%21%40211b876e17718485324842549e62d2%2112000033353662262%21sea%21NO%21905713470%21X%211%210%21n_tag%3A-29919%3Bd%3Ac3ce268b%3Bm03_new_user%3A-29895%3BpisId%3A5000000200967456&curPageLogUid=YmctihEjOJlR&utparam-url=scene%3Asearch%7Cquery_from%3A%7Cx_object_id%3A1005005508763350%7C_p_origin_prod%3A) | [link](https://duckduckgo.com/?q=6mm+ON-OFF-ON+momentary+mini+toggle+switch) |
+| [2-Position Slide Switch](#2-position-slide-switch) | 1 | [link](https://www.aliexpress.com/item/1005005599546167.html?spm=a2g0o.productlist.main.2.7917KBC1KBC1h5&algo_pvid=4d0f15b9-562f-4814-aafe-d4d9f4a693d4&algo_exp_id=4d0f15b9-562f-4814-aafe-d4d9f4a693d4-1&pdp_ext_f=%7B%22order%22%3A%22623%22%2C%22eval%22%3A%221%22%2C%22fromPage%22%3A%22search%22%7D&pdp_npi=6%40dis%21EUR%210.42%210.33%21%21%210.49%210.39%21%40210384cc17718488695244373e9f9a%2112000051255765647%21sea%21NO%21905713470%21X%211%210%21n_tag%3A-29919%3Bd%3Ac3ce268b%3Bm03_new_user%3A-29895&curPageLogUid=Z06wKh2FtbXN&utparam-url=scene%3Asearch%7Cquery_from%3A%7Cx_object_id%3A1005005599546167%7C_p_origin_prod%3A) | [link](https://duckduckgo.com/?q=2+position+slide+switch+mini) |
+| [3 mm LEDs](#3-mm-leds) | 4 | [link](https://www.aliexpress.com/item/1005003337160679.html?spm=a2g0o.productlist.main.12.36ad36f3aKSGmz&aem_p4p_detail=202602230416233790044699928800003534901&algo_pvid=6297ca25-5218-4b52-9d7f-83a5da48904c&algo_exp_id=6297ca25-5218-4b52-9d7f-83a5da48904c-11&pdp_ext_f=%7B%22order%22%3A%221367%22%2C%22spu_best_type%22%3A%22price%22%2C%22eval%22%3A%221%22%2C%22fromPage%22%3A%22search%22%7D&pdp_npi=6%40dis%21EUR%212.31%212.20%21%21%212.67%212.54%21%40211b61a417718489834581319e5cfe%2112000025285943047%21sea%21NO%21905713470%21X%211%210%21n_tag%3A-29919%3Bd%3Ac3ce268b%3Bm03_new_user%3A-29895&curPageLogUid=1RgopR6tFMAH&utparam-url=scene%3Asearch%7Cquery_from%3A%7Cx_object_id%3A1005003337160679%7C_p_origin_prod%3A&search_p4p_id=202602230416233790044699928800003534901_3) | [link](https://duckduckgo.com/?q=3mm+LED) |
 
-1 x Rasberrry pi 5 cooler:
+## Compute And Power
 
-https://www.kjell.com/no/produkter/data/raspberry-pi/joy-it-robust-aluminiumskabinett-for-raspberry-pi-5-p88410
+### Raspberry Pi 5, 8 GB
 
-1 x NOS 450 TKL keyboard
-https://www.elkjop.no/product/pc-datautstyr-og-kontor/pc-tilbehor/mus-tastatur/tastatur/nos-c-450-mini-pro-rgb-gamingtastatur-1973/327262
+Quantity: 1
 
-1 x 10.1 inch IPS touch LCD screen
+Specifications:
+- Raspberry Pi 5 single-board computer
+- 8 GB RAM version
+- USB-C power input
+- Dual micro-HDMI display outputs
+- 40-pin GPIO header
 
-https://www.aliexpress.com/item/1005001311947746.html?spm=a2g0o.productlist.main.5.d607qHnDqHnDg5&algo_pvid=f733027e-e3b3-40c4-82aa-fa6762af9178&algo_exp_id=f733027e-e3b3-40c4-82aa-fa6762af9178-4&pdp_ext_f=%7B%22order%22%3A%22203%22%2C%22eval%22%3A%221%22%2C%22fromPage%22%3A%22search%22%7D&pdp_npi=6%40dis%21EUR%2162.27%2158.94%21%21%21494.96%21468.50%21%40211b80d117718496044041525e8452%2112000015661776796%21sea%21NO%21905713470%21X%211%210%21n_tag%3A-29919%3Bd%3Ac3ce268b%3Bm03_new_user%3A-29895&curPageLogUid=q2qqPFQmRrBm&utparam-url=scene%3Asearch%7Cquery_from%3A%7Cx_object_id%3A1005001311947746%7C_p_origin_prod%3A
+Links:
+- [Creator reference](https://no.rs-online.com/web/p/raspberry-pi/0219255?cm_mmc=NO-PLA-DS3A-_-google-_-CSS_NO_EN_Pmax_Test-_--_-219255&matchtype=&&gclsrc=aw.ds&gad_source=1&gad_campaignid=20298225819&gbraid=0AAAAADkeWNNM22_IVzPWWPXKteiN9dU3n&gclid=CjwKCAiAkvDMBhBMEiwAnUA9Bda0b4-84Nr2l1eq-tLgsCP1wFOeHvoippWgN7HSQk9cVJ-S7HWWQBoCJtIQAvD_BwE)
+- [Generic search](https://duckduckgo.com/?q=Raspberry+Pi+5+8GB)
 
-1 x N-pn battery.
+### Joy-IT Power Management Board For Raspberry Pi
 
-https://www.scandinavianphoto.no/jupio/np-f970-10050mah-usb-c-input-1061086?_gl=1*1egj611*_up*MQ..*_gs*MQ..&gclid=CjwKCAiAkvDMBhBMEiwAnUA9BY5sMGsIEGkahJAyACMaOqKd51eR54hWRQpXCfJpuzd1-8D9EK2UQRoCTAUQAvD_BwE&gbraid=0AAAAAD7wLDBaqEHkDx796WWIzLpQ90hlU
+Quantity: 1
 
-6x 0B self locking connector female and male
+Specifications:
+- Power management or power supply module for Raspberry Pi 3, 4, and 5
+- Intended to manage external power for the cyberdeck build
+- Confirm input voltage, output current, battery support, and Raspberry Pi 5 mechanical compatibility before ordering
 
-https://www.aliexpress.com/item/1005008630749310.html?spm=a2g0o.order_list.order_list_main.226.2ac11802y60YIY
+Links:
+- [Creator reference](https://www.kjell.com/no/produkter/data/raspberry-pi/joy-it-stromstyringskort-for-raspberry-pi-3-4-og-5-p88409?utm_source=google&utm_medium=cpc&utm_campaign=NO%20%7C%20Shopping%20Category&utm_id=23554678753&gad_source=1&gad_campaignid=23554678753&gbraid=0AAAAADcA9cwm7tEi4DGEqshMJOQGAZmGM&gclid=CjwKCAiAkvDMBhBMEiwAnUA9Bb11cW340NAFo1qricJX56ATAIpR24Xnc7_1AqccmRroMTKr5KwlcxoCHooQAvD_BwE)
+- [Generic search](https://duckduckgo.com/?q=joy+it+energy+mini)
 
-1 x 2B self locking connector with female plug.
+### Raspberry Pi 5 Aluminum Cooling Case
 
-https://www.aliexpress.com/item/1005005348326872.html?spm=a2g0o.productlist.main.12.27bdL3YdL3YdfY&aem_p4p_detail=20260223041952939481064044600002923257&algo_pvid=9d335b38-f0bc-4a89-b765-3f67b99217db&algo_exp_id=9d335b38-f0bc-4a89-b765-3f67b99217db-11&pdp_ext_f=%7B%22order%22%3A%22555%22%2C%22eval%22%3A%221%22%2C%22fromPage%22%3A%22search%22%7D&pdp_npi=6%40dis%21EUR%2111.16%218.03%21%21%2112.88%219.27%21%40210384b217718491920953005e4d67%2112000032708276815%21sea%21NO%21905713470%21X%211%210%21n_tag%3A-29919%3Bd%3Ac3ce268b%3Bm03_new_user%3A-29895&curPageLogUid=74deDfk1d9z9&utparam-url=scene%3Asearch%7Cquery_from%3A%7Cx_object_id%3A1005005348326872%7C_p_origin_prod%3A&search_p4p_id=20260223041952939481064044600002923257_3
+Quantity: 1
 
-2 x Y2M connector 8pin female and male
+Specifications:
+- Joy-IT robust aluminum enclosure for Raspberry Pi 5
+- Used as a passive cooling case or heatsink-style enclosure
+- Confirm that the case does not conflict with GPIO, display, or internal mounting clearances
 
-https://www.aliexpress.com/item/4000650649567.html?spm=a2g0o.productlist.main.1.6e644abalUtqB9&algo_pvid=f078181e-900f-4d18-8942-ab93a7526c4e&algo_exp_id=f078181e-900f-4d18-8942-ab93a7526c4e-0&pdp_ext_f=%7B%22order%22%3A%22227%22%2C%22eval%22%3A%221%22%2C%22fromPage%22%3A%22search%22%7D&pdp_npi=6%40dis%21EUR%212.99%212.99%21%21%213.45%213.45%21%4021038e6617718491097817431e3334%2110000005200204781%21sea%21NO%21905713470%21X%211%210%21n_tag%3A-29919%3Bd%3Ac3ce268b%3Bm03_new_user%3A-29895&curPageLogUid=ntdSUsUGDLOf&utparam-url=scene%3Asearch%7Cquery_from%3A%7Cx_object_id%3A4000650649567%7C_p_origin_prod%3A
+Links:
+- [Creator reference](https://www.kjell.com/no/produkter/data/raspberry-pi/joy-it-robust-aluminiumskabinett-for-raspberry-pi-5-p88410)
+- [Generic search](https://duckduckgo.com/?q=Joy-IT+robust+aluminum+case+Raspberry+Pi+5)
 
-2 x Pogo pin GF50-09140-4024: 
-https://www.aliexpress.com/item/1005004693750812.html?spm=a2g0o.productlist.main.4.fe8a7510uZDa8O&algo_pvid=e355b9b1-a66a-465b-bca3-e3311b2fd34a&aem_p4p_detail=2026022303573510910880972595240003164091&algo_exp_id=e355b9b1-a66a-465b-bca3-e3311b2fd34a-3&pdp_ext_f=%7B%22order%22%3A%22384%22%2C%22eval%22%3A%221%22%2C%22fromPage%22%3A%22search%22%7D&pdp_npi=6%40dis%21EUR%212.46%212.36%21%21%212.84%212.72%21%40211b815c17718478555706424eb2a1%2112000038034838423%21sea%21NO%21905713470%21X%211%210%21n_tag%3A-29919%3Bd%3Ac3ce268b%3Bm03_new_user%3A-29895%3BpisId%3A5000000200980252&curPageLogUid=xG00PYGQ8IYg&utparam-url=scene%3Asearch%7Cquery_from%3A%7Cx_object_id%3A1005004693750812%7C_p_origin_prod%3A&search_p4p_id=2026022303573510910880972595240003164091_1
+### NP-F970 Battery With USB-C Input
 
-1 x rotary encoder with click:
+Quantity: 1
 
-https://www.aliexpress.com/item/1005006128088045.html?spm=a2g0o.productlist.main.1.91a366925vXHcn&algo_pvid=1fe69f4c-fb30-4c2c-bf02-2721e63c6bed&algo_exp_id=1fe69f4c-fb30-4c2c-bf02-2721e63c6bed-0&pdp_ext_f=%7B%22order%22%3A%22541%22%2C%22eval%22%3A%221%22%2C%22fromPage%22%3A%22search%22%7D&pdp_npi=6%40dis%21EUR%212.36%212.27%21%21%212.72%212.62%21%40211b815c17718484316555889eb2a0%2112000035881381466%21sea%21NO%21905713470%21X%211%210%21n_tag%3A-29919%3Bd%3Ac3ce268b%3Bm03_new_user%3A-29895&curPageLogUid=AQqsQHsG0Sc4&utparam-url=scene%3Asearch%7Cquery_from%3A%7Cx_object_id%3A1005006128088045%7C_p_origin_prod%3A
+Specifications:
+- Sony NP-F style battery pack
+- NP-F970 size
+- 10050 mAh capacity in the creator reference
+- USB-C input charging support
+- Confirm output voltage, discharge rating, and connector compatibility with the power module
 
-3 x 16mm momentary switches.
-https://www.aliexpress.com/item/1005009579949777.html?spm=a2g0o.productlist.main.1.3ace23f0HeYR1S&algo_pvid=5867ac58-f6e8-44ff-a2ff-2d26cb5e8f4e&algo_exp_id=5867ac58-f6e8-44ff-a2ff-2d26cb5e8f4e-0&pdp_ext_f=%7B%22order%22%3A%226%22%2C%22eval%22%3A%221%22%2C%22fromPage%22%3A%22search%22%7D&pdp_npi=6%40dis%21EUR%213.85%213.68%21%21%2130.64%2129.28%21%40211b612817718484586922153ef972%2112000049522702615%21sea%21NO%21905713470%21X%211%210%21n_tag%3A-29919%3Bd%3Ac3ce268b%3Bm03_new_user%3A-29895&curPageLogUid=ZhxhZ2yxGIzJ&utparam-url=scene%3Asearch%7Cquery_from%3A%7Cx_object_id%3A1005009579949777%7C_p_origin_prod%3A
+Links:
+- [Creator reference](https://www.scandinavianphoto.no/jupio/np-f970-10050mah-usb-c-input-1061086?_gl=1*1egj611*_up*MQ..*_gs*MQ..&gclid=CjwKCAiAkvDMBhBMEiwAnUA9BY5sMGsIEGkahJAyACMaOqKd51eR54hWRQpXCfJpuzd1-8D9EK2UQRoCTAUQAvD_BwE&gbraid=0AAAAAD7wLDBaqEHkDx796WWIzLpQ90hlU)
+- [Generic search](https://duckduckgo.com/?q=NP-F970+10050mAh+USB-C+input+battery)
 
-10x 12x12 tactile buttons
+## Display And Video
 
-https://www.aliexpress.com/item/1005010485096642.html?spm=a2g0o.productlist.main.1.25fe2d51zABxOU&algo_pvid=221d32c1-86d5-4a50-b5f3-c482f58dcdfc&algo_exp_id=221d32c1-86d5-4a50-b5f3-c482f58dcdfc-0&pdp_ext_f=%7B%22order%22%3A%22158%22%2C%22spu_best_type%22%3A%22price%22%2C%22eval%22%3A%221%22%2C%22fromPage%22%3A%22search%22%7D&pdp_npi=6%40dis%21EUR%213.36%211.39%21%21%2126.74%2111.06%21%40211b6a7a17718496413512900e0633%2112000052561945672%21sea%21NO%21905713470%21X%211%210%21n_tag%3A-29919%3Bd%3Ac3ce268b%3Bm03_new_user%3A-29895%3BpisId%3A5000000200970435&curPageLogUid=1PbE81DGYibH&utparam-url=scene%3Asearch%7Cquery_from%3A%7Cx_object_id%3A1005010485096642%7C_p_origin_prod%3A
+### 10.1 Inch IPS Touch LCD
 
+Quantity: 1
 
-1 x 12mm momentary switch.
+Specifications:
+- 10.1 inch LCD panel
+- IPS display type
+- Touch input support
+- Confirm resolution, HDMI input, touch interface type, power input, and mounting dimensions before ordering
 
-https://www.aliexpress.com/item/1005010335756032.html?spm=a2g0o.productlist.main.5.54c63653Lc8MFB&algo_pvid=6d81dff8-3297-4705-95c2-77e3f2fe94c9&algo_exp_id=6d81dff8-3297-4705-95c2-77e3f2fe94c9-4&pdp_ext_f=%7B%22order%22%3A%2257%22%2C%22eval%22%3A%221%22%2C%22fromPage%22%3A%22search%22%7D&pdp_npi=6%40dis%21EUR%219.83%214.25%21%21%2178.12%2133.78%21%40211b618e17718485069396564eebdd%2112000052021992055%21sea%21NO%21905713470%21X%211%210%21n_tag%3A-29919%3Bd%3Ac3ce268b%3Bm03_new_user%3A-29895%3BpisId%3A5000000200974340&curPageLogUid=QfkSBUw4SyuI&utparam-url=scene%3Asearch%7Cquery_from%3A%7Cx_object_id%3A1005010335756032%7C_p_origin_prod%3A
+Links:
+- [Creator reference](https://www.aliexpress.com/item/1005001311947746.html?spm=a2g0o.productlist.main.5.d607qHnDqHnDg5&algo_pvid=f733027e-e3b3-40c4-82aa-fa6762af9178&algo_exp_id=f733027e-e3b3-40c4-82aa-fa6762af9178-4&pdp_ext_f=%7B%22order%22%3A%22203%22%2C%22eval%22%3A%221%22%2C%22fromPage%22%3A%22search%22%7D&pdp_npi=6%40dis%21EUR%2162.27%2158.94%21%21%21494.96%21468.50%21%40211b80d117718496044041525e8452%2112000015661776796%21sea%21NO%21905713470%21X%211%210%21n_tag%3A-29919%3Bd%3Ac3ce268b%3Bm03_new_user%3A-29895&curPageLogUid=q2qqPFQmRrBm&utparam-url=scene%3Asearch%7Cquery_from%3A%7Cx_object_id%3A1005001311947746%7C_p_origin_prod%3A)
+- [Generic search](https://duckduckgo.com/?q=10.1+inch+IPS+touch+LCD+HDMI+Raspberry+Pi)
 
-1 x 6mm on-on toggle switch
+### Micro-HDMI Ribbon Cable Set
 
-https://www.aliexpress.com/item/1005005919234155.html?spm=a2g0o.productlist.main.29.6ac3S5V5S5V5Xm&algo_pvid=a7523d10-969b-494e-b433-d31603133085&algo_exp_id=a7523d10-969b-494e-b433-d31603133085-28&pdp_ext_f=%7B%22order%22%3A%22296%22%2C%22eval%22%3A%221%22%2C%22fromPage%22%3A%22search%22%7D&pdp_npi=6%40dis%21EUR%210.62%210.62%21%21%210.72%210.72%21%40211b619a17718489119092560eb5c6%2112000034852814775%21sea%21NO%21905713470%21X%211%210%21n_tag%3A-29919%3Bd%3Ac3ce268b%3Bm03_new_user%3A-29895&curPageLogUid=mUMB35geuwId&utparam-url=scene%3Asearch%7Cquery_from%3A%7Cx_object_id%3A1005005919234155%7C_p_origin_prod%3A
+Quantity: 1 set
 
-1 x 6mm on-off-on momentary toggle switch
-https://www.aliexpress.com/item/1005005508763350.html?spm=a2g0o.productlist.main.10.7642DKEODKEORj&algo_pvid=b16efa23-27fe-414c-9dbe-dd0c58a3931f&algo_exp_id=b16efa23-27fe-414c-9dbe-dd0c58a3931f-9&pdp_ext_f=%7B%22order%22%3A%22226%22%2C%22spu_best_type%22%3A%22price%22%2C%22eval%22%3A%221%22%2C%22fromPage%22%3A%22search%22%7D&pdp_npi=6%40dis%21EUR%211.64%211.42%21%21%211.89%211.64%21%40211b876e17718485324842549e62d2%2112000033353662262%21sea%21NO%21905713470%21X%211%210%21n_tag%3A-29919%3Bd%3Ac3ce268b%3Bm03_new_user%3A-29895%3BpisId%3A5000000200967456&curPageLogUid=YmctihEjOJlR&utparam-url=scene%3Asearch%7Cquery_from%3A%7Cx_object_id%3A1005005508763350%7C_p_origin_prod%3A
+Specifications:
+- 90 degree micro-HDMI to ribbon connector
+- 50 cm HDMI ribbon cable
+- Ribbon cable to HDMI male plug
+- Used to route video inside the cyberdeck enclosure
+- Confirm micro-HDMI orientation, ribbon length, and HDMI connector direction against the printed parts
 
-1 x  Slide Switch 2 Position
+Links:
+- [Creator reference](https://www.aliexpress.com/item/1005001591237744.html?spm=a2g0o.productlist.main.4.316cU0ggU0ggIg&aem_p4p_detail=2026022304173411405903031933080003173417&algo_pvid=69baf832-79ef-4f1e-8588-e22392534c15&algo_exp_id=69baf832-79ef-4f1e-8588-e22392534c15-3&pdp_ext_f=%7B%22order%22%3A%221975%22%2C%22eval%22%3A%221%22%2C%22fromPage%22%3A%22search%22%7D&pdp_npi=6%40dis%21EUR%210.61%210.61%21%21%210.70%210.70%21%4021038e6617718490545856138e3334%2112000016707628678%21sea%21NO%21905713470%21X%211%210%21n_tag%3A-29919%3Bd%3Ac3ce268b%3Bm03_new_user%3A-29895&curPageLogUid=EAp8SScI4vH4&utparam-url=scene%3Asearch%7Cquery_from%3A%7Cx_object_id%3A1005001591237744%7C_p_origin_prod%3A&search_p4p_id=2026022304173411405903031933080003173417_1)
+- [Generic search](https://duckduckgo.com/?q=micro+HDMI+90+degree+ribbon+cable+50cm+HDMI+male)
 
-https://www.aliexpress.com/item/1005005599546167.html?spm=a2g0o.productlist.main.2.7917KBC1KBC1h5&algo_pvid=4d0f15b9-562f-4814-aafe-d4d9f4a693d4&algo_exp_id=4d0f15b9-562f-4814-aafe-d4d9f4a693d4-1&pdp_ext_f=%7B%22order%22%3A%22623%22%2C%22eval%22%3A%221%22%2C%22fromPage%22%3A%22search%22%7D&pdp_npi=6%40dis%21EUR%210.42%210.33%21%21%210.49%210.39%21%40210384cc17718488695244373e9f9a%2112000051255765647%21sea%21NO%21905713470%21X%211%210%21n_tag%3A-29919%3Bd%3Ac3ce268b%3Bm03_new_user%3A-29895&curPageLogUid=Z06wKh2FtbXN&utparam-url=scene%3Asearch%7Cquery_from%3A%7Cx_object_id%3A1005005599546167%7C_p_origin_prod%3A
+## Input Devices
 
-4 x 3 mm LED
+### NOS C-450 Mini Pro RGB Keyboard
 
-https://www.aliexpress.com/item/1005003337160679.html?spm=a2g0o.productlist.main.12.36ad36f3aKSGmz&aem_p4p_detail=202602230416233790044699928800003534901&algo_pvid=6297ca25-5218-4b52-9d7f-83a5da48904c&algo_exp_id=6297ca25-5218-4b52-9d7f-83a5da48904c-11&pdp_ext_f=%7B%22order%22%3A%221367%22%2C%22spu_best_type%22%3A%22price%22%2C%22eval%22%3A%221%22%2C%22fromPage%22%3A%22search%22%7D&pdp_npi=6%40dis%21EUR%212.31%212.20%21%21%212.67%212.54%21%40211b61a417718489834581319e5cfe%2112000025285943047%21sea%21NO%21905713470%21X%211%210%21n_tag%3A-29919%3Bd%3Ac3ce268b%3Bm03_new_user%3A-29895&curPageLogUid=1RgopR6tFMAH&utparam-url=scene%3Asearch%7Cquery_from%3A%7Cx_object_id%3A1005003337160679%7C_p_origin_prod%3A&search_p4p_id=202602230416233790044699928800003534901_3
+Quantity: 1
 
-Micro HDMi to ribbon connector 90 degree / HDMI ribbon cable 50 cm / Ribbon cable to HDMI male plug.
-https://www.aliexpress.com/item/1005001591237744.html?spm=a2g0o.productlist.main.4.316cU0ggU0ggIg&aem_p4p_detail=2026022304173411405903031933080003173417&algo_pvid=69baf832-79ef-4f1e-8588-e22392534c15&algo_exp_id=69baf832-79ef-4f1e-8588-e22392534c15-3&pdp_ext_f=%7B%22order%22%3A%221975%22%2C%22eval%22%3A%221%22%2C%22fromPage%22%3A%22search%22%7D&pdp_npi=6%40dis%21EUR%210.61%210.61%21%21%210.70%210.70%21%4021038e6617718490545856138e3334%2112000016707628678%21sea%21NO%21905713470%21X%211%210%21n_tag%3A-29919%3Bd%3Ac3ce268b%3Bm03_new_user%3A-29895&curPageLogUid=EAp8SScI4vH4&utparam-url=scene%3Asearch%7Cquery_from%3A%7Cx_object_id%3A1005001591237744%7C_p_origin_prod%3A&search_p4p_id=2026022304173411405903031933080003173417_1
+Specifications:
+- Compact TKL-style gaming keyboard
+- RGB backlight
+- USB keyboard interface
+- Confirm physical dimensions before cutting or printing keyboard mounts
+
+Links:
+- [Creator reference](https://www.elkjop.no/product/pc-datautstyr-og-kontor/pc-tilbehor/mus-tastatur/tastatur/nos-c-450-mini-pro-rgb-gamingtastatur-1973/327262)
+- [Generic search](https://duckduckgo.com/?q=NOS+C-450+Mini+PRO+RGB+gamingtastatur+%281973%29)
+
+### Trackball Donor Electronics
+
+Quantity: 1
+
+Specifications:
+- Trackball electronics donor for the right-side trackball module
+- The README notes that the current build harvests electronics from a Logitech Trackman Marble
+- Confirm PCB shape, sensor position, button wiring, USB cable routing, and fit against the printed trackball module before ordering
+- This is a current build dependency rather than an ideal long-term design; custom electronics may replace it in the future
+
+Links:
+- Creator reference: not specified in the original hardware list
+- [Generic search](https://duckduckgo.com/?q=logitech+trackman+marble)
+
+### Rotary Encoder With Push Button
+
+Quantity: 1
+
+Specifications:
+- Incremental rotary encoder
+- Integrated momentary push button
+- PCB or panel mounting depending on selected variant
+- Confirm shaft length, shaft diameter, detent count, and pin layout before ordering
+
+Links:
+- [Creator reference](https://www.aliexpress.com/item/1005006128088045.html?spm=a2g0o.productlist.main.1.91a366925vXHcn&algo_pvid=1fe69f4c-fb30-4c2c-bf02-2721e63c6bed&algo_exp_id=1fe69f4c-fb30-4c2c-bf02-2721e63c6bed-0&pdp_ext_f=%7B%22order%22%3A%22541%22%2C%22eval%22%3A%221%22%2C%22fromPage%22%3A%22search%22%7D&pdp_npi=6%40dis%21EUR%212.36%212.27%21%21%212.72%212.62%21%40211b815c17718484316555889eb2a0%2112000035881381466%21sea%21NO%21905713470%21X%211%210%21n_tag%3A-29919%3Bd%3Ac3ce268b%3Bm03_new_user%3A-29895&curPageLogUid=AQqsQHsG0Sc4&utparam-url=scene%3Asearch%7Cquery_from%3A%7Cx_object_id%3A1005006128088045%7C_p_origin_prod%3A)
+- [Generic search](https://duckduckgo.com/?q=rotary+encoder+with+push+button+shaft)
+
+## Connectors
+
+### 0B Self-Locking Connector Sets
+
+Quantity: 6 sets
+
+Specifications:
+- LEMO-style 0B shell size connector
+- Self-locking push-pull mechanism
+- Matching male and female connectors
+- Pin count should be selected according to the module interface
+- The creator appears to use both 2-pin and 4-pin variants in the assembly video
+- A 2-pin connector is likely suitable for a simple power module connection
+- A 4-pin connector is likely suitable for modules that need a standard USB 2.0 link, with power and data lines
+- Future modules may need more pins: for example, a full RS-232 module may require a 9-pin connector if all DB9-style signals are exposed
+- Confirm pin count, panel/cable mount style, solder/crimp contacts, current rating, voltage rating, and available shell size before ordering
+
+Links:
+- [Creator reference](https://www.aliexpress.com/item/1005008630749310.html?spm=a2g0o.order_list.order_list_main.226.2ac11802y60YIY)
+- [Generic search](https://duckduckgo.com/?q=0B+self+locking+push+pull+connector+male+female)
+
+### 2B Self-Locking Connector With Female Plug
+
+Quantity: 1
+
+Specifications:
+- LEMO-style 2B shell size connector
+- Self-locking push-pull mechanism
+- Female plug required for this build
+- Pin count should be selected according to the module interface
+- The creator appears to use both 2-pin and 4-pin variants in the assembly video
+- A 2-pin connector is likely suitable for a simple power module connection
+- A 4-pin connector is likely suitable for modules that need a standard USB 2.0 link, with power and data lines
+- Future modules may need more pins: for example, a full RS-232 module may require a 9-pin connector if all DB9-style signals are exposed
+- Confirm pin count, keying, panel/cable mount style, solder/crimp contacts, current rating, voltage rating, and available shell size before ordering
+
+Links:
+- [Creator reference](https://www.aliexpress.com/item/1005005348326872.html?spm=a2g0o.productlist.main.12.27bdL3YdL3YdfY&aem_p4p_detail=20260223041952939481064044600002923257&algo_pvid=9d335b38-f0bc-4a89-b765-3f67b99217db&algo_exp_id=9d335b38-f0bc-4a89-b765-3f67b99217db-11&pdp_ext_f=%7B%22order%22%3A%22555%22%2C%22eval%22%3A%221%22%2C%22fromPage%22%3A%22search%22%7D&pdp_npi=6%40dis%21EUR%2111.16%218.03%21%21%2112.88%219.27%21%40210384b217718491920953005e4d67%2112000032708276815%21sea%21NO%21905713470%21X%211%210%21n_tag%3A-29919%3Bd%3Ac3ce268b%3Bm03_new_user%3A-29895&curPageLogUid=74deDfk1d9z9&utparam-url=scene%3Asearch%7Cquery_from%3A%7Cx_object_id%3A1005005348326872%7C_p_origin_prod%3A&search_p4p_id=20260223041952939481064044600002923257_3)
+- [Generic search](https://duckduckgo.com/?q=2B+self+locking+push+pull+connector+female+plug)
+
+### Y2M 8-Pin Connector Sets
+
+Quantity: 2 sets
+
+Specifications:
+- Y2M-style circular connector
+- 8-pin male and female pair
+- Confirm panel/cable mount style, wire termination, waterproof rating, and connector diameter before ordering
+
+Links:
+- [Creator reference](https://www.aliexpress.com/item/4000650649567.html?spm=a2g0o.productlist.main.1.6e644abalUtqB9&algo_pvid=f078181e-900f-4d18-8942-ab93a7526c4e&algo_exp_id=f078181e-900f-4d18-8942-ab93a7526c4e-0&pdp_ext_f=%7B%22order%22%3A%22227%22%2C%22eval%22%3A%221%22%2C%22fromPage%22%3A%22search%22%7D&pdp_npi=6%40dis%21EUR%212.99%212.99%21%21%213.45%213.45%21%4021038e6617718491097817431e3334%2110000005200204781%21sea%21NO%21905713470%21X%211%210%21n_tag%3A-29919%3Bd%3Ac3ce268b%3Bm03_new_user%3A-29895&curPageLogUid=ntdSUsUGDLOf&utparam-url=scene%3Asearch%7Cquery_from%3A%7Cx_object_id%3A4000650649567%7C_p_origin_prod%3A)
+- [Generic search](https://duckduckgo.com/?q=Y2M+8+pin+connector+male+female)
+
+### Pogo Pin GF50-09140-4024
+
+Quantity: 2
+
+Specifications:
+- Spring-loaded pogo contact
+- Part number or reference: GF50-09140-4024
+- Confirm travel, compressed height, current rating, and mounting footprint before ordering
+
+Links:
+- [Creator reference](https://www.aliexpress.com/item/1005004693750812.html?spm=a2g0o.productlist.main.4.fe8a7510uZDa8O&algo_pvid=e355b9b1-a66a-465b-bca3-e3311b2fd34a&aem_p4p_detail=2026022303573510910880972595240003164091&algo_exp_id=e355b9b1-a66a-465b-bca3-e3311b2fd34a-3&pdp_ext_f=%7B%22order%22%3A%22384%22%2C%22eval%22%3A%221%22%2C%22fromPage%22%3A%22search%22%7D&pdp_npi=6%40dis%21EUR%212.46%212.36%21%21%212.84%212.72%21%40211b815c17718478555706424eb2a1%2112000038034838423%21sea%21NO%21905713470%21X%211%210%21n_tag%3A-29919%3Bd%3Ac3ce268b%3Bm03_new_user%3A-29895%3BpisId%3A5000000200980252&curPageLogUid=xG00PYGQ8IYg&utparam-url=scene%3Asearch%7Cquery_from%3A%7Cx_object_id%3A1005004693750812%7C_p_origin_prod%3A&search_p4p_id=2026022303573510910880972595240003164091_1)
+- [Generic search](https://duckduckgo.com/?q=GF50-09140-4024+pogo+pin)
+
+## Switches And Indicators
+
+### 16 mm Momentary Push Buttons
+
+Quantity: 3
+
+Specifications:
+- 16 mm panel-mount push button
+- Momentary action
+- Confirm normally-open or normally-closed contact type, illumination option, voltage rating, and panel depth before ordering
+
+Links:
+- [Creator reference](https://www.aliexpress.com/item/1005009579949777.html?spm=a2g0o.productlist.main.1.3ace23f0HeYR1S&algo_pvid=5867ac58-f6e8-44ff-a2ff-2d26cb5e8f4e&algo_exp_id=5867ac58-f6e8-44ff-a2ff-2d26cb5e8f4e-0&pdp_ext_f=%7B%22order%22%3A%226%22%2C%22eval%22%3A%221%22%2C%22fromPage%22%3A%22search%22%7D&pdp_npi=6%40dis%21EUR%213.85%213.68%21%21%2130.64%2129.28%21%40211b612817718484586922153ef972%2112000049522702615%21sea%21NO%21905713470%21X%211%210%21n_tag%3A-29919%3Bd%3Ac3ce268b%3Bm03_new_user%3A-29895&curPageLogUid=ZhxhZ2yxGIzJ&utparam-url=scene%3Asearch%7Cquery_from%3A%7Cx_object_id%3A1005009579949777%7C_p_origin_prod%3A)
+- [Generic search](https://duckduckgo.com/?q=16mm+Panel+Hole+Metal+Button+Switch)
+
+### 12 x 12 mm Tactile Buttons
+
+Quantity: 10
+
+Specifications:
+- 12 x 12 mm tactile push button
+- Momentary action
+- Through-hole or PCB-mount depending on selected variant
+- Confirm button height, cap compatibility, and pin spacing before ordering
+
+Links:
+- [Creator reference](https://www.aliexpress.com/item/1005010485096642.html?spm=a2g0o.productlist.main.1.25fe2d51zABxOU&algo_pvid=221d32c1-86d5-4a50-b5f3-c482f58dcdfc&algo_exp_id=221d32c1-86d5-4a50-b5f3-c482f58dcdfc-0&pdp_ext_f=%7B%22order%22%3A%22158%22%2C%22spu_best_type%22%3A%22price%22%2C%22eval%22%3A%221%22%2C%22fromPage%22%3A%22search%22%7D&pdp_npi=6%40dis%21EUR%213.36%211.39%21%21%2126.74%2111.06%21%40211b6a7a17718496413512900e0633%2112000052561945672%21sea%21NO%21905713470%21X%211%210%21n_tag%3A-29919%3Bd%3Ac3ce268b%3Bm03_new_user%3A-29895%3BpisId%3A5000000200970435&curPageLogUid=1PbE81DGYibH&utparam-url=scene%3Asearch%7Cquery_from%3A%7Cx_object_id%3A1005010485096642%7C_p_origin_prod%3A)
+- [Generic search](https://duckduckgo.com/?q=Tactile+Push+Button+Switch+Momentary+12*12*7.3MM)
+
+### 12 mm Momentary Push Button
+
+Quantity: 1
+
+Specifications:
+- 12 mm panel-mount push button
+- Momentary action
+- Confirm contact type, illumination option, voltage rating, and panel depth before ordering
+
+Links:
+- [Creator reference](https://www.aliexpress.com/item/1005010335756032.html?spm=a2g0o.productlist.main.5.54c63653Lc8MFB&algo_pvid=6d81dff8-3297-4705-95c2-77e3f2fe94c9&algo_exp_id=6d81dff8-3297-4705-95c2-77e3f2fe94c9-4&pdp_ext_f=%7B%22order%22%3A%2257%22%2C%22eval%22%3A%221%22%2C%22fromPage%22%3A%22search%22%7D&pdp_npi=6%40dis%21EUR%219.83%214.25%21%21%2178.12%2133.78%21%40211b618e17718485069396564eebdd%2112000052021992055%21sea%21NO%21905713470%21X%211%210%21n_tag%3A-29919%3Bd%3Ac3ce268b%3Bm03_new_user%3A-29895%3BpisId%3A5000000200974340&curPageLogUid=QfkSBUw4SyuI&utparam-url=scene%3Asearch%7Cquery_from%3A%7Cx_object_id%3A1005010335756032%7C_p_origin_prod%3A)
+- [Generic search](https://duckduckgo.com/?q=12mm+momentary+push+button+panel+mount)
+
+### 6 mm ON-ON Toggle Switch
+
+Quantity: 1
+
+Specifications:
+- Mini toggle switch
+- ON-ON latching action
+- 6 mm mounting bushing or panel hole class
+- Confirm pole count, current rating, and solder lug or PCB terminal style before ordering
+
+Links:
+- [Creator reference](https://www.aliexpress.com/item/1005005919234155.html?spm=a2g0o.productlist.main.29.6ac3S5V5S5V5Xm&algo_pvid=a7523d10-969b-494e-b433-d31603133085&algo_exp_id=a7523d10-969b-494e-b433-d31603133085-28&pdp_ext_f=%7B%22order%22%3A%22296%22%2C%22eval%22%3A%221%22%2C%22fromPage%22%3A%22search%22%7D&pdp_npi=6%40dis%21EUR%210.62%210.62%21%21%210.72%210.72%21%40211b619a17718489119092560eb5c6%2112000034852814775%21sea%21NO%21905713470%21X%211%210%21n_tag%3A-29919%3Bd%3Ac3ce268b%3Bm03_new_user%3A-29895&curPageLogUid=mUMB35geuwId&utparam-url=scene%3Asearch%7Cquery_from%3A%7Cx_object_id%3A1005005919234155%7C_p_origin_prod%3A)
+- [Generic search](https://duckduckgo.com/?q=6mm+ON-ON+mini+toggle+switch)
+
+### 6 mm ON-OFF-ON Momentary Toggle Switch
+
+Quantity: 1
+
+Specifications:
+- Mini toggle switch
+- ON-OFF-ON action
+- Momentary return behavior as required by the build
+- 6 mm mounting bushing or panel hole class
+- Confirm pole count, current rating, and terminal style before ordering
+
+Links:
+- [Creator reference](https://www.aliexpress.com/item/1005005508763350.html?spm=a2g0o.productlist.main.10.7642DKEODKEORj&algo_pvid=b16efa23-27fe-414c-9dbe-dd0c58a3931f&algo_exp_id=b16efa23-27fe-414c-9dbe-dd0c58a3931f-9&pdp_ext_f=%7B%22order%22%3A%22226%22%2C%22spu_best_type%22%3A%22price%22%2C%22eval%22%3A%221%22%2C%22fromPage%22%3A%22search%22%7D&pdp_npi=6%40dis%21EUR%211.64%211.42%21%21%211.89%211.64%21%40211b876e17718485324842549e62d2%2112000033353662262%21sea%21NO%21905713470%21X%211%210%21n_tag%3A-29919%3Bd%3Ac3ce268b%3Bm03_new_user%3A-29895%3BpisId%3A5000000200967456&curPageLogUid=YmctihEjOJlR&utparam-url=scene%3Asearch%7Cquery_from%3A%7Cx_object_id%3A1005005508763350%7C_p_origin_prod%3A)
+- [Generic search](https://duckduckgo.com/?q=6mm+ON-OFF-ON+momentary+mini+toggle+switch)
+
+### 2-Position Slide Switch
+
+Quantity: 1
+
+Specifications:
+- Two-position slide switch
+- Latching action
+- Confirm SPDT/SPST configuration, current rating, actuator size, and mounting footprint before ordering
+
+Links:
+- [Creator reference](https://www.aliexpress.com/item/1005005599546167.html?spm=a2g0o.productlist.main.2.7917KBC1KBC1h5&algo_pvid=4d0f15b9-562f-4814-aafe-d4d9f4a693d4&algo_exp_id=4d0f15b9-562f-4814-aafe-d4d9f4a693d4-1&pdp_ext_f=%7B%22order%22%3A%22623%22%2C%22eval%22%3A%221%22%2C%22fromPage%22%3A%22search%22%7D&pdp_npi=6%40dis%21EUR%210.42%210.33%21%21%210.49%210.39%21%40210384cc17718488695244373e9f9a%2112000051255765647%21sea%21NO%21905713470%21X%211%210%21n_tag%3A-29919%3Bd%3Ac3ce268b%3Bm03_new_user%3A-29895&curPageLogUid=Z06wKh2FtbXN&utparam-url=scene%3Asearch%7Cquery_from%3A%7Cx_object_id%3A1005005599546167%7C_p_origin_prod%3A)
+- [Generic search](https://duckduckgo.com/?q=2+position+slide+switch+mini)
+
+### 3 mm LEDs
+
+Quantity: 4
+
+Specifications:
+- 3 mm through-hole LEDs
+- Confirm color, forward voltage, current rating, and whether current-limiting resistors are required in the circuit
+
+Links:
+- [Creator reference](https://www.aliexpress.com/item/1005003337160679.html?spm=a2g0o.productlist.main.12.36ad36f3aKSGmz&aem_p4p_detail=202602230416233790044699928800003534901&algo_pvid=6297ca25-5218-4b52-9d7f-83a5da48904c&algo_exp_id=6297ca25-5218-4b52-9d7f-83a5da48904c-11&pdp_ext_f=%7B%22order%22%3A%221367%22%2C%22spu_best_type%22%3A%22price%22%2C%22eval%22%3A%221%22%2C%22fromPage%22%3A%22search%22%7D&pdp_npi=6%40dis%21EUR%212.31%212.20%21%21%212.67%212.54%21%40211b61a417718489834581319e5cfe%2112000025285943047%21sea%21NO%21905713470%21X%211%210%21n_tag%3A-29919%3Bd%3Ac3ce268b%3Bm03_new_user%3A-29895&curPageLogUid=1RgopR6tFMAH&utparam-url=scene%3Asearch%7Cquery_from%3A%7Cx_object_id%3A1005003337160679%7C_p_origin_prod%3A&search_p4p_id=202602230416233790044699928800003534901_3)
+- [Generic search](https://duckduckgo.com/?q=3mm+LED)


### PR DESCRIPTION
## Summary

This PR updates the hardware bill of materials to make the component list easier to read and more useful for builders outside the creator's original supplier region.

The original creator links are kept unchanged, including their original parameters, so attribution or possible affiliate links are preserved. Each component also now includes a generic DuckDuckGo search link to help users find local suppliers, compare prices, or identify equivalent parts more easily.

A summary table was added at the top of the document to provide a quick overview of the required components, quantities, creator links, and generic search links.

## Notes

The component choices and wording can still be refined. Please feel free to request changes, especially around connector variants, pin counts, or alternative part references.

## Disclosure

AI assistance was used to help format and structure the hardware bill of materials. The content was reviewed and adjusted manually before submission.